### PR TITLE
Update binary format parser for 1.1.0

### DIFF
--- a/bin-format/src/format.rs
+++ b/bin-format/src/format.rs
@@ -773,7 +773,7 @@ impl fmt::Debug for Rgb {
 
 #[derive(Debug, Clone, Parse)]
 pub struct Player {
-    pub z_i32_3: [i32; 3],
+    pub z_i32_4: [i32; 4],
     pub z_f32: [f32; 8],
     pub transform: Transform,
     pub yaw: f32,


### PR DESCRIPTION
Everything is still broken but now it doesn't crash.

For proper documentation about the binary format, please refer to:
https://github.com/TTFH/Teardown-Converter/blob/main/src/scene.h
https://github.com/TTFH/Teardown-Converter/blob/main/src/entity.h